### PR TITLE
Persist escrows to Firebase

### DIFF
--- a/src/@types/escrow.entity.ts
+++ b/src/@types/escrow.entity.ts
@@ -1,0 +1,17 @@
+import { Escrow } from "@trustless-work/escrow/types";
+
+export interface EscrowRecord {
+  escrowId: string;
+  createdBy: string;
+  signer: string;
+  engagementId: string;
+  title: string;
+  description: string;
+  amount: string;
+  platformFee: string;
+  receiverMemo: number;
+  roles: Escrow["roles"];
+  trustline: Escrow["trustline"];
+  milestones: Escrow["milestones"];
+  createdAt: number | unknown;
+}

--- a/src/components/modules/escrows/hooks/initialize-escrow-form.hook.ts
+++ b/src/components/modules/escrows/hooks/initialize-escrow-form.hook.ts
@@ -15,6 +15,7 @@ import { signTransaction } from "../../auth/helpers/stellar-wallet-kit.helper";
 import { handleError } from "@/errors/utils/handle-errors";
 import { AxiosError } from "axios";
 import { WalletError } from "@/@types/errors.entity";
+import { saveEscrow } from "../lib/escrow";
 import {
   useInitializeEscrow as useInitializeEscrowHook,
   useSendTransaction,
@@ -210,6 +211,12 @@ export const useInitializeEscrow = () => {
         setEscrow(escrow);
         setActiveTab("escrow");
         toast.success("Escrow Created");
+
+        try {
+          await saveEscrow(escrow, walletAddress || "");
+        } catch (err) {
+          console.error("Error saving escrow:", err);
+        }
       }
     } catch (error: unknown) {
       const mappedError = handleError(error as AxiosError | WalletError);

--- a/src/components/modules/escrows/hooks/use-user-escrows.hook.ts
+++ b/src/components/modules/escrows/hooks/use-user-escrows.hook.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { getEscrowsForWallet } from "../lib/escrow";
+import { EscrowRecord } from "@/@types/escrow.entity";
+
+export const useUserEscrows = (walletAddress: string) => {
+  const [escrows, setEscrows] = useState<EscrowRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!walletAddress) {
+        setEscrows([]);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      const res = await getEscrowsForWallet(walletAddress);
+      setEscrows(res);
+      setLoading(false);
+    };
+    load();
+  }, [walletAddress]);
+
+  return { escrows, loading };
+};

--- a/src/components/modules/escrows/hooks/use-user-escrows.hook.ts
+++ b/src/components/modules/escrows/hooks/use-user-escrows.hook.ts
@@ -5,21 +5,30 @@ import { EscrowRecord } from "@/@types/escrow.entity";
 export const useUserEscrows = (walletAddress: string) => {
   const [escrows, setEscrows] = useState<EscrowRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
       if (!walletAddress) {
         setEscrows([]);
         setLoading(false);
+        setError(null);
         return;
       }
-      setLoading(true);
-      const res = await getEscrowsForWallet(walletAddress);
-      setEscrows(res);
-      setLoading(false);
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await getEscrowsForWallet(walletAddress);
+        setEscrows(res);
+      } catch (err) {
+        console.error("Error loading escrows:", err);
+        setError("Failed to load escrows");
+      } finally {
+        setLoading(false);
+      }
     };
     load();
   }, [walletAddress]);
 
-  return { escrows, loading };
+  return { escrows, loading, error };
 };

--- a/src/components/modules/escrows/lib/escrow.ts
+++ b/src/components/modules/escrows/lib/escrow.ts
@@ -1,0 +1,75 @@
+import { db } from "@/lib/firebase";
+import {
+  collection,
+  doc,
+  setDoc,
+  getDocs,
+  query,
+  where,
+  serverTimestamp,
+  Timestamp,
+} from "firebase/firestore";
+import { Escrow } from "@trustless-work/escrow/types";
+import { EscrowRecord } from "@/@types/escrow.entity";
+
+const convertTimestamp = (timestamp: Timestamp | Date | number): number => {
+  if (timestamp instanceof Timestamp) {
+    return timestamp.toMillis();
+  }
+  if (timestamp instanceof Date) {
+    return timestamp.getTime();
+  }
+  if (typeof timestamp === "number") {
+    return timestamp;
+  }
+  return Date.now();
+};
+
+export const saveEscrow = async (escrow: Escrow, createdBy: string) => {
+  const escrowRef = doc(db, "escrows", escrow.contractId);
+  const data: EscrowRecord = {
+    escrowId: escrow.contractId,
+    createdBy,
+    signer: escrow.signer,
+    engagementId: escrow.engagementId,
+    title: escrow.title,
+    description: escrow.description,
+    amount: escrow.amount,
+    platformFee: escrow.platformFee,
+    receiverMemo: escrow.receiverMemo,
+    roles: escrow.roles,
+    trustline: escrow.trustline,
+    milestones: escrow.milestones,
+    createdAt: serverTimestamp(),
+  };
+  await setDoc(escrowRef, data);
+};
+
+export const getEscrowsForWallet = async (
+  walletAddress: string,
+): Promise<EscrowRecord[]> => {
+  if (!walletAddress) return [];
+
+  const escrowsCol = collection(db, "escrows");
+  const queries = [
+    query(escrowsCol, where("createdBy", "==", walletAddress)),
+    query(escrowsCol, where("signer", "==", walletAddress)),
+    query(escrowsCol, where("roles.approver", "==", walletAddress)),
+    query(escrowsCol, where("roles.serviceProvider", "==", walletAddress)),
+    query(escrowsCol, where("roles.platformAddress", "==", walletAddress)),
+    query(escrowsCol, where("roles.releaseSigner", "==", walletAddress)),
+    query(escrowsCol, where("roles.disputeResolver", "==", walletAddress)),
+    query(escrowsCol, where("roles.receiver", "==", walletAddress)),
+  ];
+
+  const snapshots = await Promise.all(queries.map(getDocs));
+  const docs = snapshots.flatMap((snap) =>
+    snap.docs.map((d) => {
+      const data = d.data() as EscrowRecord;
+      return { ...data, createdAt: convertTimestamp(data.createdAt) };
+    }),
+  );
+  const unique = new Map<string, EscrowRecord>();
+  docs.forEach((doc) => unique.set(doc.escrowId, doc));
+  return Array.from(unique.values());
+};

--- a/src/components/modules/escrows/ui/components/EscrowList.tsx
+++ b/src/components/modules/escrows/ui/components/EscrowList.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { EscrowRecord } from "@/@types/escrow.entity";
+
+interface Props {
+  escrows: EscrowRecord[];
+  loading: boolean;
+}
+
+export function EscrowList({ escrows, loading }: Props) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full p-4">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  if (escrows.length === 0) {
+    return (
+      <div className="p-4 text-center text-muted-foreground">
+        No escrows found for this wallet.
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-[300px]">
+      <div className="space-y-2">
+        {escrows.map((escrow) => (
+          <Card key={escrow.escrowId} className="border shadow-sm">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-medium">
+                {escrow.title}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm space-y-1">
+              <div>Contract ID: {escrow.escrowId}</div>
+              <div>Amount: {escrow.amount}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/components/modules/escrows/ui/pages/dashboard.tsx
+++ b/src/components/modules/escrows/ui/pages/dashboard.tsx
@@ -12,10 +12,18 @@ import { MainTabs } from "../tabs/MainTabs";
 import { ConnectWalletWarning } from "../ConnectWalletWarning";
 import { useUserEscrows } from "../../hooks/use-user-escrows.hook";
 import { EscrowList } from "../components/EscrowList";
+import { useEffect } from "react";
+import { toast } from "sonner";
 
 export function Loans() {
   const { walletAddress } = useWalletContext();
-  const { escrows, loading } = useUserEscrows(walletAddress || "");
+  const { escrows, loading, error } = useUserEscrows(walletAddress || "");
+
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+    }
+  }, [error]);
 
   return (
     <div className="space-y-8 p-4">

--- a/src/components/modules/escrows/ui/pages/dashboard.tsx
+++ b/src/components/modules/escrows/ui/pages/dashboard.tsx
@@ -10,9 +10,12 @@ import {
 import { useWalletContext } from "@/providers/wallet.provider";
 import { MainTabs } from "../tabs/MainTabs";
 import { ConnectWalletWarning } from "../ConnectWalletWarning";
+import { useUserEscrows } from "../../hooks/use-user-escrows.hook";
+import { EscrowList } from "../components/EscrowList";
 
 export function Loans() {
   const { walletAddress } = useWalletContext();
+  const { escrows, loading } = useUserEscrows(walletAddress || "");
 
   return (
     <div className="space-y-8 p-4">
@@ -28,6 +31,16 @@ export function Loans() {
           {walletAddress ? <MainTabs /> : <ConnectWalletWarning />}
         </CardContent>
       </Card>
+      {walletAddress && (
+        <Card className="shadow-none border">
+          <CardHeader>
+            <CardTitle className="text-xl">Your Escrows</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <EscrowList escrows={escrows} loading={loading} />
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/errors/utils/handle-errors.ts
+++ b/src/errors/utils/handle-errors.ts
@@ -8,7 +8,14 @@ export const handleError = (error: AxiosError | WalletError): ErrorResponse => {
   if (axios.isAxiosError(error)) {
     const axiosError = error as AxiosError<ApiError>;
     const code = axiosError.response?.status || 500;
-    const message = axiosError.response?.data?.message || error.message;
+    let message = axiosError.response?.data?.message || error.message;
+    if (
+      typeof message === "string" &&
+      message.toLowerCase().includes("token not valid")
+    ) {
+      message =
+        "Invalid Trustless Work API key. Please check your configuration.";
+    }
     return {
       message,
       code,


### PR DESCRIPTION
## Summary
- save escrow data in Firestore and provide helper to fetch escrows by wallet
- expose EscrowRecord type
- call the save function after escrow creation
- display stored escrows in the loans dashboard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684a30767fa08320bc31934ae544a813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dashboard section displaying a list of your escrow records, including contract ID and amount, when a wallet is connected.
  - Introduced a loading indicator while escrow data is being fetched.
  - If no escrows are found, a message is shown to inform the user.
  - Enabled saving and retrieving escrow records linked to your wallet.
- **Bug Fixes**
  - Improved error messages for invalid API keys to enhance clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->