### PR TITLE
Make dashboard use real wallet data

### DIFF
--- a/src/components/modules/dashboard/hooks/useDashboard.hook.ts
+++ b/src/components/modules/dashboard/hooks/useDashboard.hook.ts
@@ -2,215 +2,52 @@
 
 import { useState, useEffect } from "react";
 import { useWalletContext } from "@/providers/wallet.provider";
+import { useUserContext } from "@/providers/user.provider";
+import { getUserChats } from "@/components/modules/chat/lib/chat";
+import { UserProfile } from "@/@types/user.entity";
 
-interface DashboardStats {
-  totalLoans: number;
-  activeLoans: number;
-  totalAmount: number;
-  availableBalance: number;
-  pendingApprovals: number;
-  completedLoans: number;
+interface DashboardData {
+  profile: UserProfile | null;
+  chatCount: number;
+  address: string | null;
+  walletName: string | null;
+  loading: boolean;
 }
 
-interface RecentActivity {
-  id: string;
-  type:
-    | "loan_created"
-    | "loan_approved"
-    | "milestone_completed"
-    | "payment_received"
-    | "loan_completed";
-  title: string;
-  description: string;
-  amount?: number;
-  date: Date;
-  status?: "pending" | "completed" | "rejected";
-}
+export function useDashboard(): DashboardData {
+  const { walletAddress: address, walletName } = useWalletContext();
+  const { profile, loading: profileLoading } = useUserContext();
 
-interface LoanData {
-  month: string;
-  amount: number;
-}
-
-interface UpcomingMilestone {
-  id: string;
-  loanTitle: string;
-  description: string;
-  dueDate: Date;
-  amount: number;
-}
-
-export function useDashboard() {
-  const { walletAddress: address } = useWalletContext();
-  const [loading, setLoading] = useState<boolean>(true);
-  const [stats, setStats] = useState<DashboardStats>({
-    totalLoans: 0,
-    activeLoans: 0,
-    totalAmount: 0,
-    availableBalance: 0,
-    pendingApprovals: 0,
-    completedLoans: 0,
-  });
-  const [recentActivity, setRecentActivity] = useState<RecentActivity[]>([]);
-  const [loanTrends, setLoanTrends] = useState<LoanData[]>([]);
-  const [upcomingMilestones, setUpcomingMilestones] = useState<
-    UpcomingMilestone[]
-  >([]);
+  const [chatCount, setChatCount] = useState(0);
+  const [chatsLoading, setChatsLoading] = useState(true);
 
   useEffect(() => {
-    const loadDashboardData = async () => {
-      setLoading(true);
+    const loadChats = async () => {
+      if (!address) {
+        setChatCount(0);
+        setChatsLoading(false);
+        return;
+      }
 
-      setTimeout(() => {
-        setStats({
-          totalLoans: 24,
-          activeLoans: 8,
-          totalAmount: 125000,
-          availableBalance: 42500,
-          pendingApprovals: 3,
-          completedLoans: 16,
-        });
-
-        setRecentActivity([
-          {
-            id: "1",
-            type: "loan_approved",
-            title: "Loan Approved",
-            description:
-              'Your loan offer for "Business Expansion Funding" was approved',
-            amount: 15000,
-            date: new Date(Date.now() - 1000 * 60 * 60 * 2),
-            status: "completed",
-          },
-          {
-            id: "2",
-            type: "milestone_completed",
-            title: "Milestone Completed",
-            description: 'Milestone 2: "Product Development" was completed',
-            amount: 5000,
-            date: new Date(Date.now() - 1000 * 60 * 60 * 24),
-            status: "completed",
-          },
-          {
-            id: "3",
-            type: "payment_received",
-            title: "Payment Received",
-            description: 'You received a payment for "Inventory Financing"',
-            amount: 2500,
-            date: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2),
-            status: "completed",
-          },
-          {
-            id: "4",
-            type: "loan_created",
-            title: "Loan Created",
-            description:
-              'You created a new loan offer for "Seasonal Inventory"',
-            amount: 7500,
-            date: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
-            status: "pending",
-          },
-          {
-            id: "5",
-            type: "loan_completed",
-            title: "Loan Completed",
-            description: 'Loan "Working Capital" was fully repaid',
-            amount: 10000,
-            date: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5),
-            status: "completed",
-          },
-        ]);
-
-        setLoanTrends([
-          { month: "Jan", amount: 15000 },
-          { month: "Feb", amount: 18000 },
-          { month: "Mar", amount: 22000 },
-          { month: "Apr", amount: 17000 },
-          { month: "May", amount: 25000 },
-          { month: "Jun", amount: 28000 },
-        ]);
-
-        setUpcomingMilestones([
-          {
-            id: "1",
-            loanTitle: "Business Expansion Funding",
-            description: "Market Research Completion",
-            dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
-            amount: 3000,
-          },
-          {
-            id: "2",
-            loanTitle: "Tech Startup Investment",
-            description: "MVP Development",
-            dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 5),
-            amount: 5000,
-          },
-          {
-            id: "3",
-            loanTitle: "Inventory Financing",
-            description: "Supplier Payment Confirmation",
-            dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
-            amount: 2500,
-          },
-        ]);
-
-        setLoading(false);
-      }, 1500);
+      try {
+        const chats = await getUserChats(address);
+        setChatCount(chats.length);
+      } catch (err) {
+        console.error("Error loading chats:", err);
+        setChatCount(0);
+      } finally {
+        setChatsLoading(false);
+      }
     };
 
-    loadDashboardData();
-  }, []);
-
-  const formatCurrency = (amount: number): string => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: 0,
-    }).format(amount);
-  };
-
-  const formatDate = (date: Date): string => {
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffSecs = Math.floor(diffMs / 1000);
-    const diffMins = Math.floor(diffSecs / 60);
-    const diffHours = Math.floor(diffMins / 60);
-    const diffDays = Math.floor(diffHours / 24);
-
-    if (diffDays > 0) {
-      return diffDays === 1 ? "Yesterday" : `${diffDays} days ago`;
-    } else if (diffHours > 0) {
-      return `${diffHours} ${diffHours === 1 ? "hour" : "hours"} ago`;
-    } else if (diffMins > 0) {
-      return `${diffMins} ${diffMins === 1 ? "minute" : "minutes"} ago`;
-    } else {
-      return "Just now";
-    }
-  };
-
-  const formatDueDate = (date: Date): string => {
-    const now = new Date();
-    const diffMs = date.getTime() - now.getTime();
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    if (diffDays === 0) {
-      return "Today";
-    } else if (diffDays === 1) {
-      return "Tomorrow";
-    } else {
-      return `In ${diffDays} days`;
-    }
-  };
+    loadChats();
+  }, [address]);
 
   return {
-    loading,
-    stats,
-    recentActivity,
-    loanTrends,
-    upcomingMilestones,
-    formatCurrency,
-    formatDate,
-    formatDueDate,
+    profile,
+    chatCount,
     address,
+    walletName,
+    loading: profileLoading || chatsLoading,
   };
 }

--- a/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
+++ b/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
@@ -2,6 +2,18 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import {
+  Wallet,
+  User,
+  MessageCircle,
+  MapPin,
+  Phone,
+  CreditCard,
+  Shield,
+  Activity,
+  CheckCircle2,
+} from "lucide-react";
 import { useDashboard } from "../../hooks/useDashboard.hook";
 
 export function DashboardOverview() {
@@ -9,69 +21,287 @@ export function DashboardOverview() {
 
   if (loading) {
     return (
-      <div className="p-6 space-y-4">
-        <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-24 w-full" />
-        <Skeleton className="h-24 w-full" />
-        <Skeleton className="h-24 w-full" />
+      <div className="p-6 space-y-6 pb-32">
+        <Skeleton className="h-8 w-64 mb-4" />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[...Array(3)].map((_, i) => (
+            <Card key={i} className="overflow-hidden">
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-24 mb-1" />
+                <Skeleton className="h-8 w-32" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-4 w-full mb-2" />
+                <Skeleton className="h-4 w-3/4" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     );
   }
 
+  const formatAddress = (addr: string) => {
+    if (!addr) return "Not connected";
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+  };
+
   return (
-    <div className="p-6 space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>Wallet Information</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          <p>
-            <span className="font-medium">Address:</span>{" "}
-            {address || "Not connected"}
-          </p>
-          {walletName && (
-            <p>
-              <span className="font-medium">Wallet:</span> {walletName}
-            </p>
-          )}
-        </CardContent>
-      </Card>
+    <div className="p-6 space-y-6 pb-32">
+      {/* Header */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-1 bg-gradient-to-b from-emerald-500 to-teal-500 rounded-full" />
+          <h1 className="text-3xl font-bold tracking-tight">
+            Dashboard Overview
+          </h1>
+        </div>
+        <p className="text-muted-foreground pl-3 border-l-2 border-muted">
+          Your account summary, wallet information, and activity overview.
+        </p>
+      </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>User Profile</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {profile ? (
-            <>
-              <p>
-                <span className="font-medium">Name:</span> {profile.firstName}{" "}
-                {profile.lastName}
-              </p>
-              <p>
-                <span className="font-medium">Country:</span> {profile.country}
-              </p>
-              <p>
-                <span className="font-medium">Phone:</span>{" "}
-                {profile.phoneNumber}
-              </p>
-            </>
-          ) : (
-            <p>No profile data available.</p>
-          )}
-        </CardContent>
-      </Card>
+      {/* Main Cards Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* Wallet Information Card */}
+        <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
+          <div className="h-1 bg-gradient-to-r from-emerald-500 to-teal-500" />
+          <CardHeader className="pb-3">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <div className="bg-emerald-100 rounded-full p-2">
+                <Wallet className="h-5 w-5 text-emerald-600" />
+              </div>
+              Wallet Information
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground flex items-center gap-2">
+                  <CreditCard className="h-4 w-4" />
+                  Address
+                </span>
+                <div className="flex items-center gap-2">
+                  {address ? (
+                    <>
+                      <Badge
+                        variant="outline"
+                        className="bg-emerald-50 text-emerald-700 border-emerald-200"
+                      >
+                        <CheckCircle2 className="h-3 w-3 mr-1" />
+                        Connected
+                      </Badge>
+                    </>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="bg-amber-50 text-amber-700 border-amber-200"
+                    >
+                      Disconnected
+                    </Badge>
+                  )}
+                </div>
+              </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Chats Summary</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p>
-            <span className="font-medium">Total chats:</span> {chatCount}
-          </p>
-        </CardContent>
-      </Card>
+              <div className="bg-muted/50 rounded-lg p-3">
+                <p className="font-mono text-sm break-all">
+                  {formatAddress(address || "")}
+                </p>
+              </div>
+
+              {walletName && (
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground flex items-center gap-2">
+                    <Shield className="h-4 w-4" />
+                    Wallet Type
+                  </span>
+                  <span className="font-medium">{walletName}</span>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* User Profile Card */}
+        <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
+          <div className="h-1 bg-gradient-to-r from-teal-500 to-emerald-500" />
+          <CardHeader className="pb-3">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <div className="bg-teal-100 rounded-full p-2">
+                <User className="h-5 w-5 text-teal-600" />
+              </div>
+              User Profile
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {profile ? (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">
+                    Full Name
+                  </span>
+                  <span className="font-medium">
+                    {profile.firstName} {profile.lastName}
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground flex items-center gap-2">
+                    <MapPin className="h-4 w-4" />
+                    Country
+                  </span>
+                  <span className="font-medium">{profile.country}</span>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground flex items-center gap-2">
+                    <Phone className="h-4 w-4" />
+                    Phone
+                  </span>
+                  <span className="font-medium">{profile.phoneNumber}</span>
+                </div>
+
+                <div className="pt-2 mt-3 border-t">
+                  <Badge
+                    variant="outline"
+                    className="bg-emerald-50 text-emerald-700 border-emerald-200"
+                  >
+                    <CheckCircle2 className="h-3 w-3 mr-1" />
+                    Profile Complete
+                  </Badge>
+                </div>
+              </div>
+            ) : (
+              <div className="text-center py-6">
+                <div className="bg-muted rounded-full w-12 h-12 flex items-center justify-center mx-auto mb-3">
+                  <User className="h-6 w-6 text-muted-foreground" />
+                </div>
+                <p className="text-sm text-muted-foreground mb-2">
+                  No profile data available
+                </p>
+                <Badge
+                  variant="outline"
+                  className="bg-amber-50 text-amber-700 border-amber-200"
+                >
+                  Setup Required
+                </Badge>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Activity Summary Card */}
+        <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
+          <div className="h-1 bg-gradient-to-r from-emerald-500 to-teal-500" />
+          <CardHeader className="pb-3">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <div className="bg-emerald-100 rounded-full p-2">
+                <Activity className="h-5 w-5 text-emerald-600" />
+              </div>
+              Activity Summary
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground flex items-center gap-2">
+                  <MessageCircle className="h-4 w-4" />
+                  Total Chats
+                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-2xl font-bold text-emerald-600">
+                    {chatCount}
+                  </span>
+                </div>
+              </div>
+
+              <div className="bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 rounded-lg p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium">Chat Activity</span>
+                  <Badge
+                    variant="outline"
+                    className="bg-emerald-50 text-emerald-700 border-emerald-200"
+                  >
+                    Active
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  You have participated in {chatCount} conversation
+                  {chatCount !== 1 ? "s" : ""} on the platform.
+                </p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 pt-2">
+                <div className="text-center">
+                  <p className="text-lg font-bold text-teal-600">
+                    {chatCount > 0 ? "100%" : "0%"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">Engagement</p>
+                </div>
+                <div className="text-center">
+                  <p className="text-lg font-bold text-emerald-600">
+                    {chatCount > 5 ? "High" : chatCount > 0 ? "Medium" : "Low"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Activity Level
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Additional Info Section */}
+      {(profile || address) && (
+        <Card className="border-border shadow-sm">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-xl">Account Status</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="flex items-center gap-3">
+                <div
+                  className={`w-3 h-3 rounded-full ${address ? "bg-emerald-500" : "bg-amber-500"}`}
+                />
+                <div>
+                  <p className="font-medium">Wallet Connection</p>
+                  <p className="text-sm text-muted-foreground">
+                    {address ? "Connected and verified" : "Not connected"}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div
+                  className={`w-3 h-3 rounded-full ${profile ? "bg-emerald-500" : "bg-amber-500"}`}
+                />
+                <div>
+                  <p className="font-medium">Profile Setup</p>
+                  <p className="text-sm text-muted-foreground">
+                    {profile
+                      ? "Complete profile information"
+                      : "Profile setup required"}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div
+                  className={`w-3 h-3 rounded-full ${chatCount > 0 ? "bg-emerald-500" : "bg-gray-400"}`}
+                />
+                <div>
+                  <p className="font-medium">Platform Activity</p>
+                  <p className="text-sm text-muted-foreground">
+                    {chatCount > 0 ? "Active participant" : "New to platform"}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
+++ b/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
@@ -1,562 +1,77 @@
 "use client";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Progress } from "@/components/ui/progress";
-import {
-  TrendingUp,
-  DollarSign,
-  CreditCard,
-  Clock,
-  CheckCircle2,
-  ArrowRight,
-  Wallet,
-  PiggyBank,
-  Activity,
-  Landmark,
-  FileText,
-  Milestone,
-  BarChart4,
-  CircleDollarSign,
-  BadgeCheck,
-  ShieldCheck,
-} from "lucide-react";
 import { useDashboard } from "../../hooks/useDashboard.hook";
 
 export function DashboardOverview() {
-  const {
-    loading,
-    stats,
-    recentActivity,
-    loanTrends,
-    formatCurrency,
-    formatDate,
-  } = useDashboard();
-
-  const getActivityIcon = (type: string) => {
-    switch (type) {
-      case "loan_created":
-        return <FileText className="h-4 w-4 text-blue-500" />;
-      case "loan_approved":
-        return <CheckCircle2 className="h-4 w-4 text-emerald-500" />;
-      case "milestone_completed":
-        return <Milestone className="h-4 w-4 text-purple-500" />;
-      case "payment_received":
-        return <DollarSign className="h-4 w-4 text-amber-500" />;
-      case "loan_completed":
-        return <BadgeCheck className="h-4 w-4 text-teal-500" />;
-      default:
-        return <Activity className="h-4 w-4 text-gray-500" />;
-    }
-  };
-
-  const getStatusBadge = (status?: string) => {
-    if (!status) return null;
-
-    switch (status) {
-      case "completed":
-        return (
-          <Badge
-            variant="outline"
-            className="bg-emerald-50 text-emerald-700 border-emerald-200"
-          >
-            Completed
-          </Badge>
-        );
-      case "pending":
-        return (
-          <Badge
-            variant="outline"
-            className="bg-amber-50 text-amber-700 border-amber-200"
-          >
-            Pending
-          </Badge>
-        );
-      case "rejected":
-        return (
-          <Badge
-            variant="outline"
-            className="bg-red-50 text-red-700 border-red-200"
-          >
-            Rejected
-          </Badge>
-        );
-      default:
-        return null;
-    }
-  };
+  const { loading, profile, address, walletName, chatCount } = useDashboard();
 
   if (loading) {
     return (
-      <div className="p-6 space-y-6 pb-32">
-        <Skeleton className="h-8 w-64 mb-4" />
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {[...Array(4)].map((_, i) => (
-            <Card key={i} className="overflow-hidden">
-              <CardHeader className="pb-2">
-                <Skeleton className="h-4 w-24 mb-1" />
-                <Skeleton className="h-8 w-32" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-4 w-full" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <Card className="lg:col-span-2">
-            <CardHeader>
-              <Skeleton className="h-6 w-40" />
-            </CardHeader>
-            <CardContent className="h-80">
-              <Skeleton className="h-full w-full" />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <Skeleton className="h-6 w-40" />
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {[...Array(5)].map((_, i) => (
-                <div key={i} className="flex gap-4">
-                  <Skeleton className="h-10 w-10 rounded-full" />
-                  <div className="space-y-2 flex-1">
-                    <Skeleton className="h-4 w-full" />
-                    <Skeleton className="h-3 w-3/4" />
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </div>
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
       </div>
     );
   }
 
   return (
-    <div className="p-6 space-y-6 pb-32">
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2">
-          <div className="h-8 w-1 bg-gradient-to-b from-emerald-500 to-teal-500 rounded-full" />
-          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        </div>
-        <p className="text-muted-foreground pl-3 border-l-2 border-muted">
-          Welcome back! Here is an overview of your loan activity and financial
-          status.
-        </p>
-      </div>
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Wallet Information</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>
+            <span className="font-medium">Address:</span>{" "}
+            {address || "Not connected"}
+          </p>
+          {walletName && (
+            <p>
+              <span className="font-medium">Wallet:</span> {walletName}
+            </p>
+          )}
+        </CardContent>
+      </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
-          <div className="h-1 bg-gradient-to-r from-emerald-500 to-teal-500" />
-          <CardHeader className="pb-2">
-            <CardDescription>Total Loan Volume</CardDescription>
-            <CardTitle className="text-2xl">
-              {formatCurrency(stats.totalAmount)}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between text-sm">
-              <div className="flex items-center text-emerald-600">
-                <TrendingUp className="h-4 w-4 mr-1" />
-                <span>12% from last month</span>
-              </div>
-              <span className="text-muted-foreground">
-                {stats.totalLoans} loans
-              </span>
-            </div>
-          </CardContent>
-        </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>User Profile</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {profile ? (
+            <>
+              <p>
+                <span className="font-medium">Name:</span> {profile.firstName}{" "}
+                {profile.lastName}
+              </p>
+              <p>
+                <span className="font-medium">Country:</span> {profile.country}
+              </p>
+              <p>
+                <span className="font-medium">Phone:</span>{" "}
+                {profile.phoneNumber}
+              </p>
+            </>
+          ) : (
+            <p>No profile data available.</p>
+          )}
+        </CardContent>
+      </Card>
 
-        <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
-          <div className="h-1 bg-gradient-to-r from-teal-500 to-emerald-500" />
-          <CardHeader className="pb-2">
-            <CardDescription>Active Loans</CardDescription>
-            <CardTitle className="text-2xl">{stats.activeLoans}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between text-sm">
-              <div className="flex items-center text-teal-600">
-                <CreditCard className="h-4 w-4 mr-1" />
-                <span>{formatCurrency(stats.totalAmount * 0.4)}</span>
-              </div>
-              <span className="text-muted-foreground">In progress</span>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
-          <div className="h-1 bg-gradient-to-r from-emerald-500 to-teal-500" />
-          <CardHeader className="pb-2">
-            <CardDescription>Available Balance</CardDescription>
-            <CardTitle className="text-2xl">
-              {formatCurrency(stats.availableBalance)}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between text-sm">
-              <div className="flex items-center text-emerald-600">
-                <Wallet className="h-4 w-4 mr-1" />
-                <span>Available to withdraw</span>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2 text-xs text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50"
-              >
-                Withdraw
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
-          <div className="h-1 bg-gradient-to-r from-teal-500 to-emerald-500" />
-          <CardHeader className="pb-2">
-            <CardDescription>Pending Approvals</CardDescription>
-            <CardTitle className="text-2xl">{stats.pendingApprovals}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between text-sm">
-              <div className="flex items-center text-teal-600">
-                <Clock className="h-4 w-4 mr-1" />
-                <span>Awaiting review</span>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2 text-xs text-teal-600 hover:text-teal-700 hover:bg-teal-50"
-              >
-                Review
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <Tabs defaultValue="earnings" className="lg:col-span-2">
-          <div className="flex items-center justify-between mb-4">
-            <TabsList className="bg-muted/80">
-              <TabsTrigger
-                value="overview"
-                className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-950"
-              >
-                Overview
-              </TabsTrigger>
-              <TabsTrigger
-                value="loans"
-                className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-950"
-              >
-                Loans
-              </TabsTrigger>
-              <TabsTrigger
-                value="earnings"
-                className="data-[state=active]:bg-white dark:data-[state=active]:bg-gray-950"
-              >
-                Earnings
-              </TabsTrigger>
-            </TabsList>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-8 gap-1 border-emerald-200 text-emerald-700 hover:bg-emerald-50"
-            >
-              <BarChart4 className="h-3.5 w-3.5" />
-              <span>Reports</span>
-            </Button>
-          </div>
-
-          <Card className="border-border shadow-sm">
-            <TabsContent value="overview" className="m-0">
-              <CardHeader className="pb-2">
-                <div className="flex items-center justify-between">
-                  <CardTitle>Financial Overview</CardTitle>
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <div className="h-3 w-3 rounded-full bg-emerald-500" />
-                      Loans
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <div className="h-3 w-3 rounded-full bg-teal-500" />
-                      Repayments
-                    </span>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="pb-6">
-                <div className="h-[300px] mt-4 flex items-end justify-between gap-2">
-                  {loanTrends.map((data, i) => (
-                    <div
-                      key={i}
-                      className="flex flex-col items-center gap-2 w-full"
-                    >
-                      <div className="w-full flex items-end justify-center gap-1 h-[250px]">
-                        <div
-                          className="w-3 bg-emerald-500 rounded-t-sm"
-                          style={{
-                            height: `${(data.amount / 30000) * 100}%`,
-                          }}
-                        />
-                        <div
-                          className="w-3 bg-teal-500 rounded-t-sm"
-                          style={{
-                            height: `${((data.amount * 0.7) / 30000) * 100}%`,
-                          }}
-                        />
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        {data.month}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </TabsContent>
-
-            <TabsContent value="loans" className="m-0">
-              <CardHeader>
-                <CardTitle>Loan Distribution</CardTitle>
-              </CardHeader>
-              <CardContent className="pb-6">
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="flex items-center gap-2">
-                        <div className="h-3 w-3 rounded-full bg-emerald-500" />
-                        Active Loans
-                      </span>
-                      <span className="font-medium">
-                        {stats.activeLoans} (
-                        {((stats.activeLoans / stats.totalLoans) * 100).toFixed(
-                          0,
-                        )}
-                        %)
-                      </span>
-                    </div>
-                    <Progress
-                      value={(stats.activeLoans / stats.totalLoans) * 100}
-                      className="h-2 bg-muted"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="flex items-center gap-2">
-                        <div className="h-3 w-3 rounded-full bg-teal-500" />
-                        Pending Loans
-                      </span>
-                      <span className="font-medium">
-                        {stats.pendingApprovals} (
-                        {(
-                          (stats.pendingApprovals / stats.totalLoans) *
-                          100
-                        ).toFixed(0)}
-                        %)
-                      </span>
-                    </div>
-                    <Progress
-                      value={(stats.pendingApprovals / stats.totalLoans) * 100}
-                      className="h-2 bg-muted"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="flex items-center gap-2">
-                        <div className="h-3 w-3 rounded-full bg-emerald-400" />
-                        Completed Loans
-                      </span>
-                      <span className="font-medium">
-                        {stats.completedLoans} (
-                        {(
-                          (stats.completedLoans / stats.totalLoans) *
-                          100
-                        ).toFixed(0)}
-                        %)
-                      </span>
-                    </div>
-                    <Progress
-                      value={(stats.completedLoans / stats.totalLoans) * 100}
-                      className="h-2 bg-muted"
-                    />
-                  </div>
-
-                  <div className="pt-4 mt-4 border-t">
-                    <div className="grid grid-cols-3 gap-4 text-center">
-                      <div className="space-y-1">
-                        <span className="text-xs text-muted-foreground">
-                          Total Loans
-                        </span>
-                        <p className="text-xl font-bold">{stats.totalLoans}</p>
-                      </div>
-                      <div className="space-y-1">
-                        <span className="text-xs text-muted-foreground">
-                          Avg. Amount
-                        </span>
-                        <p className="text-xl font-bold">
-                          {formatCurrency(stats.totalAmount / stats.totalLoans)}
-                        </p>
-                      </div>
-                      <div className="space-y-1">
-                        <span className="text-xs text-muted-foreground">
-                          Success Rate
-                        </span>
-                        <p className="text-xl font-bold text-emerald-600">
-                          94%
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </TabsContent>
-
-            <TabsContent value="earnings" className="m-0">
-              <CardHeader>
-                <CardTitle>Earnings Overview</CardTitle>
-              </CardHeader>
-              <CardContent className="pb-6">
-                <div className="space-y-6">
-                  <div className="grid grid-cols-2 gap-4">
-                    <Card className="bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 border-emerald-100 dark:border-emerald-900/50">
-                      <CardContent className="p-4">
-                        <div className="flex items-center gap-3">
-                          <div className="bg-emerald-100 rounded-full p-2">
-                            <CircleDollarSign className="h-5 w-5 text-emerald-600" />
-                          </div>
-                          <div>
-                            <p className="text-xs text-muted-foreground">
-                              Total Earnings
-                            </p>
-                            <p className="text-lg font-bold">
-                              {formatCurrency(stats.totalAmount * 0.12)}
-                            </p>
-                          </div>
-                        </div>
-                      </CardContent>
-                    </Card>
-
-                    <Card className="bg-gradient-to-br from-teal-50 to-emerald-50 dark:from-teal-950/30 dark:to-emerald-950/30 border-teal-100 dark:border-teal-900/50">
-                      <CardContent className="p-4">
-                        <div className="flex items-center gap-3">
-                          <div className="bg-teal-100 rounded-full p-2">
-                            <PiggyBank className="h-5 w-5 text-teal-600" />
-                          </div>
-                          <div>
-                            <p className="text-xs text-muted-foreground">
-                              Interest Earned
-                            </p>
-                            <p className="text-lg font-bold">
-                              {formatCurrency(stats.totalAmount * 0.08)}
-                            </p>
-                          </div>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  </div>
-
-                  <div className="space-y-2">
-                    <h4 className="text-sm font-medium">Earnings Breakdown</h4>
-                    <div className="space-y-3">
-                      <div className="flex items-center justify-between text-sm">
-                        <span className="flex items-center gap-2">
-                          <Landmark className="h-4 w-4 text-emerald-600" />
-                          Interest Income
-                        </span>
-                        <span className="font-medium">
-                          {formatCurrency(stats.totalAmount * 0.08)}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between text-sm">
-                        <span className="flex items-center gap-2">
-                          <ShieldCheck className="h-4 w-4 text-teal-600" />
-                          Platform Fees
-                        </span>
-                        <span className="font-medium">
-                          {formatCurrency(stats.totalAmount * 0.03)}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between text-sm">
-                        <span className="flex items-center gap-2">
-                          <BadgeCheck className="h-4 w-4 text-emerald-600" />
-                          Milestone Bonuses
-                        </span>
-                        <span className="font-medium">
-                          {formatCurrency(stats.totalAmount * 0.01)}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <Button className="w-full bg-gradient-to-r from-emerald-600 to-teal-500 hover:from-emerald-700 hover:to-teal-600 text-white">
-                    View Detailed Report
-                  </Button>
-                </div>
-              </CardContent>
-            </TabsContent>
-          </Card>
-        </Tabs>
-
-        <div className="space-y-6">
-          <Card className="border-border shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base">Recent Activity</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {recentActivity.slice(0, 4).map((activity) => (
-                <div key={activity.id} className="flex items-start gap-3">
-                  <div className="mt-0.5 bg-muted rounded-full p-1.5">
-                    {getActivityIcon(activity.type)}
-                  </div>
-                  <div className="space-y-1 flex-1">
-                    <div className="flex items-center justify-between">
-                      <p className="text-sm font-medium">{activity.title}</p>
-                      {getStatusBadge(activity.status)}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {activity.description}
-                    </p>
-                    <div className="flex items-center justify-between text-xs">
-                      <span className="text-muted-foreground">
-                        {formatDate(activity.date)}
-                      </span>
-                      {activity.amount && (
-                        <span className="font-medium">
-                          {formatCurrency(activity.amount)}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </CardContent>
-            <CardFooter className="pt-0">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full text-xs justify-between text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50"
-              >
-                View All Activity
-                <ArrowRight className="h-3.5 w-3.5" />
-              </Button>
-            </CardFooter>
-          </Card>
-        </div>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Chats Summary</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p>
+            <span className="font-medium">Total chats:</span> {chatCount}
+          </p>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove placeholder data from dashboard
- fetch chats and profile to show wallet info

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6850313a116483209fe0bcc8f5e4f8ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the dashboard to display only basic user profile, wallet information, and chat count.
  - Removed all financial statistics, charts, tabs, and recent activity details from the dashboard view.
  - Streamlined loading states and UI for a cleaner, more focused dashboard experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->