### PR TITLE
Change all green references to emerald-800

### DIFF
--- a/src/components/layouts/header/Header.tsx
+++ b/src/components/layouts/header/Header.tsx
@@ -21,9 +21,9 @@ export function Header() {
         <div className="ml-auto flex items-center gap-2">
           {walletAddress ? (
             <>
-              <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-emerald-50 dark:bg-emerald-950 rounded-lg border border-emerald-200 dark:border-emerald-800">
-                <Wallet className="w-4 h-4 text-emerald-600" />
-                <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+              <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-emerald-800 dark:bg-emerald-800 rounded-lg border border-emerald-800 dark:border-emerald-800">
+                <Wallet className="w-4 h-4 text-emerald-800" />
+                <span className="text-sm font-medium text-emerald-800 dark:text-emerald-800">
                   {truncateAddress(walletAddress)}
                 </span>
               </div>

--- a/src/components/layouts/header/HeaderHome.tsx
+++ b/src/components/layouts/header/HeaderHome.tsx
@@ -8,7 +8,7 @@ const HeaderHome: React.FC = () => {
     <header className="flex h-14 items-center px-4 lg:px-6">
       <div className="flex flex-1 justify-end">
         <Link href="/about-us">
-          <button className="rounded-md border border-emerald-700 bg-black px-4 py-1.5 text-emerald-400 font-medium transition-colors duration-200 hover:bg-emerald-900 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-400">
+          <button className="rounded-md border border-emerald-800 bg-black px-4 py-1.5 text-emerald-800 font-medium transition-colors duration-200 hover:bg-emerald-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-800">
             About Us
           </button>
         </Link>

--- a/src/components/layouts/sidebar/Sidebar.tsx
+++ b/src/components/layouts/sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ export function TrustBridgeSidebar() {
             />
             {!collapsed && (
               <div className="flex flex-col">
-                <span className="text-md font-bold leading-none text-emerald-600">
+                <span className="text-md font-bold leading-none text-emerald-800">
                   TrustBridge
                 </span>
                 <span className="text-xs text-muted-foreground">
@@ -73,11 +73,11 @@ export function TrustBridgeSidebar() {
                               className={cn(
                                 "group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                                 item.active
-                                  ? "bg-muted-foreground text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
+                                  ? "bg-muted-foreground text-emerald-800 dark:bg-emerald-800 dark:text-emerald-800"
                                   : "text-muted-foreground hover:bg-muted hover:text-foreground",
                                 item.highlight &&
                                   !item.active &&
-                                  " text-muted-foreground hover:from-emerald-600 hover:to-teal-600",
+                                  " text-muted-foreground hover:from-emerald-800 hover:to-teal-600",
                               )}
                             >
                               <a
@@ -88,7 +88,7 @@ export function TrustBridgeSidebar() {
                                   className={cn(
                                     "flex-shrink-0",
                                     item.active
-                                      ? "text-emerald-600 dark:text-emerald-400"
+                                      ? "text-emerald-800 dark:text-emerald-800"
                                       : item.highlight
                                         ? "text-white"
                                         : "text-muted-foreground group-hover:text-foreground",
@@ -135,7 +135,7 @@ export function TrustBridgeSidebar() {
                 src="/placeholder.svg?height=32&width=32"
                 alt="User"
               />
-              <AvatarFallback className="bg-emerald-100 text-emerald-700"></AvatarFallback>
+              <AvatarFallback className="bg-emerald-800 text-emerald-800"></AvatarFallback>
             </Avatar>
             {!collapsed && (
               <div className="flex flex-col">

--- a/src/components/modules/about-us/ui/pages/AboutUs.tsx
+++ b/src/components/modules/about-us/ui/pages/AboutUs.tsx
@@ -10,14 +10,14 @@ export default function AboutPage() {
       <div className="max-w-6xl w-full">
         <Link
           href="/"
-          className="inline-block mb-6 px-4 py-2 rounded-md border border-emerald-700 text-emerald-400 font-medium transition-colors duration-200 hover:bg-emerald-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-400"
+          className="inline-block mb-6 px-4 py-2 rounded-md border border-emerald-800 text-emerald-800 font-medium transition-colors duration-200 hover:bg-emerald-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-800"
         >
           &larr; Back to Home
         </Link>
-        <h1 className="text-4xl font-bold text-emerald-400 mb-8">About Us</h1>
+        <h1 className="text-4xl font-bold text-emerald-800 mb-8">About Us</h1>
 
         {loading && (
-          <div className="text-emerald-300 text-lg py-16 text-center">
+          <div className="text-emerald-800 text-lg py-16 text-center">
             Loading...
           </div>
         )}
@@ -28,15 +28,15 @@ export default function AboutPage() {
 
         {data && (
           <>
-            <section className="mb-6 rounded-xl border border-emerald-900 bg-black/80 p-6">
-              <h2 className="text-2xl font-semibold text-emerald-300 mb-2">
+            <section className="mb-6 rounded-xl border border-emerald-800 bg-black/80 p-6">
+              <h2 className="text-2xl font-semibold text-emerald-800 mb-2">
                 Our Mission
               </h2>
               <p className="text-white/90">{data.mission}</p>
             </section>
 
-            <section className="mb-6 rounded-xl border border-emerald-900 bg-black/80 p-6">
-              <h2 className="text-2xl font-semibold text-emerald-300 mb-2">
+            <section className="mb-6 rounded-xl border border-emerald-800 bg-black/80 p-6">
+              <h2 className="text-2xl font-semibold text-emerald-800 mb-2">
                 Our Story
               </h2>
               <p className="text-white/90" style={{ whiteSpace: "pre-line" }}>
@@ -44,22 +44,22 @@ export default function AboutPage() {
               </p>
             </section>
 
-            <section className="mb-6 rounded-xl border border-emerald-900 bg-black/80 p-6">
-              <h2 className="text-2xl font-semibold text-emerald-300 mb-4">
+            <section className="mb-6 rounded-xl border border-emerald-800 bg-black/80 p-6">
+              <h2 className="text-2xl font-semibold text-emerald-800 mb-4">
                 Our Team
               </h2>
               <div className="flex flex-col sm:flex-row justify-center items-center gap-8">
                 {data.team.map((member: TeamMember) => (
                   <div className="flex flex-col items-center" key={member.name}>
                     <div
-                      className="w-16 h-16 rounded-full bg-emerald-600 mb-2"
+                      className="w-16 h-16 rounded-full bg-emerald-800 mb-2"
                       role="img"
                       aria-label={`${member.name} avatar placeholder`}
                     />
                     <span className="text-white font-semibold">
                       {member.name}
                     </span>
-                    <span className="text-emerald-300 text-sm">
+                    <span className="text-emerald-800 text-sm">
                       {member.role}
                     </span>
                   </div>
@@ -67,8 +67,8 @@ export default function AboutPage() {
               </div>
             </section>
 
-            <section className="rounded-xl border border-emerald-900 bg-black/80 p-6">
-              <h2 className="text-2xl font-semibold text-emerald-300 mb-2">
+            <section className="rounded-xl border border-emerald-800 bg-black/80 p-6">
+              <h2 className="text-2xl font-semibold text-emerald-800 mb-2">
                 Blockchain Technology
               </h2>
               <p className="text-white/90">{data.technology}</p>

--- a/src/components/modules/auth/ui/pages/Home.tsx
+++ b/src/components/modules/auth/ui/pages/Home.tsx
@@ -31,13 +31,13 @@ export default function HomePage() {
             <div className="space-y-4">
               <Badge
                 variant="outline"
-                className="bg-emerald-50 text-emerald-700 border-emerald-200 mx-auto md:mx-0 w-fit"
+                className="bg-emerald-800 text-emerald-800 border-emerald-800 mx-auto md:mx-0 w-fit"
               >
                 Powered by Stellar Blockchain
               </Badge>
 
               <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl">
-                <span className="bg-gradient-to-r from-emerald-600 to-teal-500 bg-clip-text text-transparent">
+                <span className="bg-gradient-to-r from-emerald-800 to-teal-500 bg-clip-text text-transparent">
                   TrustBridge
                 </span>
                 <span className="block mt-2">Decentralized Microloans</span>
@@ -52,9 +52,9 @@ export default function HomePage() {
 
             {/* Mobile wallet address display */}
             {walletAddress && (
-              <div className="flex sm:hidden items-center justify-center gap-2 px-3 py-2 bg-emerald-50 dark:bg-emerald-950 rounded-lg border border-emerald-200 dark:border-emerald-800 mx-auto w-fit">
-                <Wallet className="w-4 h-4 text-emerald-600" />
-                <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+              <div className="flex sm:hidden items-center justify-center gap-2 px-3 py-2 bg-emerald-800 dark:bg-emerald-800 rounded-lg border border-emerald-800 dark:border-emerald-800 mx-auto w-fit">
+                <Wallet className="w-4 h-4 text-emerald-800" />
+                <span className="text-sm font-medium text-emerald-800 dark:text-emerald-800">
                   {truncateAddress(walletAddress)}
                 </span>
               </div>
@@ -64,9 +64,9 @@ export default function HomePage() {
               {walletAddress ? (
                 <>
                   {/* Desktop wallet address display */}
-                  <div className="hidden sm:flex items-center gap-2 px-3 py-2 bg-emerald-50 dark:bg-emerald-950 rounded-lg border border-emerald-200 dark:border-emerald-800">
-                    <Wallet className="w-4 h-4 text-emerald-600" />
-                    <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                  <div className="hidden sm:flex items-center gap-2 px-3 py-2 bg-emerald-800 dark:bg-emerald-800 rounded-lg border border-emerald-800 dark:border-emerald-800">
+                    <Wallet className="w-4 h-4 text-emerald-800" />
+                    <span className="text-sm font-medium text-emerald-800 dark:text-emerald-800">
                       {truncateAddress(walletAddress)}
                     </span>
                   </div>
@@ -85,7 +85,7 @@ export default function HomePage() {
                 <Button
                   size="lg"
                   onClick={handleConnect}
-                  className="w-full sm:w-auto bg-gradient-to-r from-emerald-600 to-teal-500 hover:from-emerald-700 hover:to-teal-600 text-white border-0"
+                  className="w-full sm:w-auto bg-gradient-to-r from-emerald-800 to-teal-500 hover:from-emerald-800 hover:to-teal-600 text-white border-0"
                 >
                   <LogIn className="w-5 h-5" />
                   <span className="ml-2">Connect Wallet</span>
@@ -96,7 +96,7 @@ export default function HomePage() {
                 <Button
                   size="lg"
                   variant="outline"
-                  className="w-full border-emerald-200 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
+                  className="w-full border-emerald-800 text-emerald-800 hover:bg-emerald-800 dark:border-emerald-800 dark:text-emerald-800 dark:hover:bg-emerald-800"
                 >
                   Explore Dashboard
                   <ArrowRight className="ml-2 h-5 w-5" />

--- a/src/components/modules/chat/ui/components/chat-list.tsx
+++ b/src/components/modules/chat/ui/components/chat-list.tsx
@@ -46,7 +46,7 @@ export function ChatList({ chats, currentWallet, loading }: ChatListProps) {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-600"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-800"></div>
       </div>
     );
   }
@@ -84,7 +84,7 @@ export function ChatList({ chats, currentWallet, loading }: ChatListProps) {
               className={cn(
                 "p-3 cursor-pointer transition-colors",
                 isActive
-                  ? "border-emerald-600 hover:border-emerald-700"
+                  ? "border-emerald-800 hover:border-emerald-800"
                   : "hover:bg-muted/50",
               )}
               onClick={() => router.push(`/dashboard/chat/${otherParticipant}`)}
@@ -95,7 +95,7 @@ export function ChatList({ chats, currentWallet, loading }: ChatListProps) {
                     src={`https://avatar.vercel.sh/${otherParticipant}.svg`} // todo: you can add profile image of the users in firebase, and then use it here
                     alt={`Avatar for ${otherParticipant}`}
                   />
-                  <AvatarFallback className="bg-emerald-100 text-emerald-700">
+                  <AvatarFallback className="bg-emerald-800 text-emerald-800">
                     {user?.firstName?.slice(0, 2).toUpperCase() ||
                       otherParticipant?.slice(0, 2).toUpperCase()}
                     {user?.lastName?.slice(0, 2).toUpperCase() ||

--- a/src/components/modules/chat/ui/components/message-bubble.tsx
+++ b/src/components/modules/chat/ui/components/message-bubble.tsx
@@ -38,7 +38,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
           className={cn(
             "rounded-2xl px-4 py-2 text-sm break-words",
             isUser
-              ? "bg-emerald-600 text-white rounded-br-md"
+              ? "bg-emerald-800 text-white rounded-br-md"
               : "bg-muted text-foreground rounded-bl-md",
           )}
         >

--- a/src/components/modules/chat/ui/dialogs/ChatDialog.tsx
+++ b/src/components/modules/chat/ui/dialogs/ChatDialog.tsx
@@ -135,7 +135,7 @@ export function ChatDialog() {
                 <Button
                   onClick={handleStartChat}
                   disabled={!targetWallet.trim()}
-                  className="bg-emerald-600 hover:bg-emerald-700 text-white"
+                  className="bg-emerald-800 hover:bg-emerald-800 text-white"
                 >
                   Start Chat
                 </Button>
@@ -180,13 +180,13 @@ export function ChatDialog() {
                         src={`https://avatar.vercel.sh/${otherWallet}.svg`}
                         alt={`Avatar for ${otherWallet}`}
                       />
-                      <AvatarFallback className="bg-emerald-100 text-emerald-700">
+                      <AvatarFallback className="bg-emerald-800 text-white">
                         {userData?.firstName?.slice(0, 2).toUpperCase() ||
                           (otherWallet as string).slice(0, 2).toUpperCase()}
                         {userData?.lastName?.slice(0, 2).toUpperCase()}
                       </AvatarFallback>
                     </Avatar>
-                    <div className="absolute -bottom-1 -right-1 w-3 h-3 bg-green-500 border-2 border-background rounded-full"></div>
+                    <div className="absolute -bottom-1 -right-1 w-3 h-3 bg-emerald-800 border-2 border-background rounded-full"></div>
                   </div>
 
                   <div className="flex-1">
@@ -203,7 +203,7 @@ export function ChatDialog() {
                         className="p-1 h-6 w-6"
                       >
                         {copiedAddress ? (
-                          <Check className="w-3 h-3 text-green-600" />
+                          <Check className="w-3 h-3 text-emerald-800" />
                         ) : (
                           <Copy className="w-3 h-3" />
                         )}
@@ -230,12 +230,12 @@ export function ChatDialog() {
                   <div className="p-4 space-y-4">
                     {loading && messages.length === 0 ? (
                       <div className="flex items-center justify-center py-8">
-                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-600"></div>
+                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-800"></div>
                       </div>
                     ) : messages.length === 0 ? (
                       <div className="flex flex-col items-center justify-center py-12 text-center">
-                        <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mb-4">
-                          <Send className="w-8 h-8 text-emerald-600" />
+                        <div className="w-16 h-16 bg-emerald-800 rounded-full flex items-center justify-center mb-4">
+                          <Send className="w-8 h-8 text-white" />
                         </div>
                         <h3 className="font-semibold text-lg mb-2">
                           Start the conversation
@@ -289,7 +289,7 @@ export function ChatDialog() {
                         }
                       }}
                       disabled={isSending}
-                      className="pr-12 bg-background border-border focus:ring-emerald-600 focus:border-emerald-600"
+                      className="pr-12 bg-background border-border focus:ring-emerald-800 focus:border-emerald-800"
                     />
                     {message.trim() && (
                       <div className="absolute right-2 top-1/2 transform -translate-y-1/2 text-xs text-muted-foreground">
@@ -300,7 +300,7 @@ export function ChatDialog() {
                   <Button
                     onClick={handleSendMessage}
                     disabled={!message.trim() || isSending}
-                    className="bg-emerald-600 hover:bg-emerald-700 text-white min-w-[44px]"
+                    className="bg-emerald-800 hover:bg-emerald-800 text-white min-w-[44px]"
                   >
                     {isSending ? (
                       <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>

--- a/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
+++ b/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
@@ -52,7 +52,7 @@ export function DashboardOverview() {
       {/* Header */}
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
-          <div className="h-8 w-1 bg-gradient-to-b from-emerald-500 to-teal-500 rounded-full" />
+          <div className="h-8 w-1 bg-gradient-to-b from-emerald-800 to-teal-500 rounded-full" />
           <h1 className="text-3xl font-bold tracking-tight">
             Dashboard Overview
           </h1>
@@ -66,11 +66,11 @@ export function DashboardOverview() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {/* Wallet Information Card */}
         <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
-          <div className="h-1 bg-gradient-to-r from-emerald-500 to-teal-500" />
+          <div className="h-1 bg-gradient-to-r from-emerald-800 to-teal-500" />
           <CardHeader className="pb-3">
             <CardTitle className="text-lg flex items-center gap-2">
-              <div className="bg-emerald-100 rounded-full p-2">
-                <Wallet className="h-5 w-5 text-emerald-600" />
+              <div className="bg-emerald-800 rounded-full p-2">
+                <Wallet className="h-5 w-5 text-emerald-800" />
               </div>
               Wallet Information
             </CardTitle>
@@ -87,7 +87,7 @@ export function DashboardOverview() {
                     <>
                       <Badge
                         variant="outline"
-                        className="bg-emerald-50 text-emerald-700 border-emerald-200"
+                        className="bg-emerald-800 text-emerald-800 border-emerald-800"
                       >
                         <CheckCircle2 className="h-3 w-3 mr-1" />
                         Connected
@@ -125,7 +125,7 @@ export function DashboardOverview() {
 
         {/* User Profile Card */}
         <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
-          <div className="h-1 bg-gradient-to-r from-teal-500 to-emerald-500" />
+          <div className="h-1 bg-gradient-to-r from-teal-500 to-emerald-800" />
           <CardHeader className="pb-3">
             <CardTitle className="text-lg flex items-center gap-2">
               <div className="bg-teal-100 rounded-full p-2">
@@ -165,7 +165,7 @@ export function DashboardOverview() {
                 <div className="pt-2 mt-3 border-t">
                   <Badge
                     variant="outline"
-                    className="bg-emerald-50 text-emerald-700 border-emerald-200"
+                    className="bg-emerald-800 text-emerald-800 border-emerald-800"
                   >
                     <CheckCircle2 className="h-3 w-3 mr-1" />
                     Profile Complete
@@ -193,11 +193,11 @@ export function DashboardOverview() {
 
         {/* Activity Summary Card */}
         <Card className="overflow-hidden border-border shadow-sm hover:shadow-md transition-shadow">
-          <div className="h-1 bg-gradient-to-r from-emerald-500 to-teal-500" />
+          <div className="h-1 bg-gradient-to-r from-emerald-800 to-teal-500" />
           <CardHeader className="pb-3">
             <CardTitle className="text-lg flex items-center gap-2">
-              <div className="bg-emerald-100 rounded-full p-2">
-                <Activity className="h-5 w-5 text-emerald-600" />
+              <div className="bg-emerald-800 rounded-full p-2">
+                <Activity className="h-5 w-5 text-emerald-800" />
               </div>
               Activity Summary
             </CardTitle>
@@ -210,18 +210,18 @@ export function DashboardOverview() {
                   Total Chats
                 </span>
                 <div className="flex items-center gap-2">
-                  <span className="text-2xl font-bold text-emerald-600">
+                  <span className="text-2xl font-bold text-emerald-800">
                     {chatCount}
                   </span>
                 </div>
               </div>
 
-              <div className="bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 rounded-lg p-4">
+              <div className="bg-gradient-to-br from-emerald-800 to-teal-50 dark:from-emerald-800 dark:to-teal-950/30 rounded-lg p-4">
                 <div className="flex items-center justify-between mb-2">
                   <span className="text-sm font-medium">Chat Activity</span>
                   <Badge
                     variant="outline"
-                    className="bg-emerald-50 text-emerald-700 border-emerald-200"
+                    className="bg-emerald-800 text-emerald-800 border-emerald-800"
                   >
                     Active
                   </Badge>
@@ -240,7 +240,7 @@ export function DashboardOverview() {
                   <p className="text-xs text-muted-foreground">Engagement</p>
                 </div>
                 <div className="text-center">
-                  <p className="text-lg font-bold text-emerald-600">
+                  <p className="text-lg font-bold text-emerald-800">
                     {chatCount > 5 ? "High" : chatCount > 0 ? "Medium" : "Low"}
                   </p>
                   <p className="text-xs text-muted-foreground">
@@ -263,7 +263,7 @@ export function DashboardOverview() {
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <div className="flex items-center gap-3">
                 <div
-                  className={`w-3 h-3 rounded-full ${address ? "bg-emerald-500" : "bg-amber-500"}`}
+                  className={`w-3 h-3 rounded-full ${address ? "bg-emerald-800" : "bg-amber-500"}`}
                 />
                 <div>
                   <p className="font-medium">Wallet Connection</p>
@@ -275,7 +275,7 @@ export function DashboardOverview() {
 
               <div className="flex items-center gap-3">
                 <div
-                  className={`w-3 h-3 rounded-full ${profile ? "bg-emerald-500" : "bg-amber-500"}`}
+                  className={`w-3 h-3 rounded-full ${profile ? "bg-emerald-800" : "bg-amber-500"}`}
                 />
                 <div>
                   <p className="font-medium">Profile Setup</p>
@@ -289,7 +289,7 @@ export function DashboardOverview() {
 
               <div className="flex items-center gap-3">
                 <div
-                  className={`w-3 h-3 rounded-full ${chatCount > 0 ? "bg-emerald-500" : "bg-gray-400"}`}
+                  className={`w-3 h-3 rounded-full ${chatCount > 0 ? "bg-emerald-800" : "bg-gray-400"}`}
                 />
                 <div>
                   <p className="font-medium">Platform Activity</p>

--- a/src/components/modules/dashboard/ui/pages/background/GradientBackground.tsx
+++ b/src/components/modules/dashboard/ui/pages/background/GradientBackground.tsx
@@ -21,7 +21,7 @@ export function GradientBackground({
   children,
   className,
   opacity = 30,
-  primaryColor = "bg-emerald-500",
+  primaryColor = "bg-emerald-800",
   secondaryColor = "bg-teal-700",
   primaryPosition = "-top-40 -right-40",
   secondaryPosition = "top-1/2 -left-40",

--- a/src/components/modules/escrows/ui/pages/dashboard.tsx
+++ b/src/components/modules/escrows/ui/pages/dashboard.tsx
@@ -14,7 +14,7 @@ export function Loans() {
         {/* Nuevo Header con texto anterior */}
         <div className="flex flex-col gap-2 p-4 pb-0">
           <div className="flex items-center gap-2">
-            <div className="h-8 w-1 bg-gradient-to-b from-emerald-500 to-teal-500 rounded-full" />
+            <div className="h-8 w-1 bg-gradient-to-b from-emerald-800 to-teal-500 rounded-full" />
             <h1 className="text-3xl font-bold tracking-tight">Loans</h1>
           </div>
           <p className="text-muted-foreground pl-3 border-l-2 border-muted">

--- a/src/components/modules/escrows/ui/sections/EscrowMilestonesSection.tsx
+++ b/src/components/modules/escrows/ui/sections/EscrowMilestonesSection.tsx
@@ -17,7 +17,7 @@ export const EscrowMilestonesSection = ({
           key={index}
           className={`border rounded-lg p-4 transition-all ${
             milestone.status === "approved" || milestone.approvedFlag
-              ? "border-green-200 dark:border-green-900 bg-green-50 dark:bg-green-900/20"
+              ? "border-emerald-800 dark:border-emerald-800 bg-emerald-800 dark:bg-emerald-800"
               : "hover:border-primary"
           }`}
         >
@@ -26,7 +26,7 @@ export const EscrowMilestonesSection = ({
               <div
                 className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full uppercase ${
                   milestone.status === "approved" || milestone.approvedFlag
-                    ? "bg-green-100 dark:bg-green-900/50"
+                    ? "bg-emerald-800 dark:bg-emerald-800"
                     : "bg-muted"
                 }`}
               >
@@ -48,7 +48,7 @@ export const EscrowMilestonesSection = ({
                     }
                     className={
                       milestone.status === "approved"
-                        ? "bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-200 hover:bg-green-200 dark:hover:bg-green-900/70 uppercase"
+                        ? "bg-emerald-800 dark:bg-emerald-800 text-emerald-800 dark:text-emerald-800 hover:bg-emerald-800 dark:hover:bg-emerald-800 uppercase"
                         : "uppercase"
                     }
                   >
@@ -64,7 +64,7 @@ export const EscrowMilestonesSection = ({
                 {milestone.approvedFlag && !milestone.status && (
                   <Badge
                     variant="outline"
-                    className="border-green-200 dark:border-green-900 text-green-800 dark:text-green-200 uppercase"
+                    className="border-emerald-800 dark:border-emerald-800 text-emerald-800 dark:text-emerald-800 uppercase"
                   >
                     <CheckCircle2 className="mr-1 h-3 w-3" /> Approved
                   </Badge>

--- a/src/components/modules/escrows/ui/sections/HeaderSection.tsx
+++ b/src/components/modules/escrows/ui/sections/HeaderSection.tsx
@@ -47,7 +47,7 @@ export const HeaderSection = ({ escrow }: HeaderSectionProps) => {
             variant="outline"
             className={
               escrow?.flags?.releaseFlag || escrow?.flags?.resolvedFlag
-                ? "bg-green-100 text-green-800 hover:bg-green-200"
+                ? "bg-emerald-800 text-emerald-800 hover:bg-emerald-800"
                 : escrow?.flags?.disputeFlag
                   ? "bg-destructive text-white hover:bg-destructive/90"
                   : ""

--- a/src/components/modules/marketplace/hooks/marketplace.hook.ts
+++ b/src/components/modules/marketplace/hooks/marketplace.hook.ts
@@ -79,7 +79,7 @@ export function useMarketplace() {
         return {
           label: "Available",
           variant: "outline" as const,
-          className: "bg-emerald-50 text-emerald-700 border-emerald-200",
+          className: "bg-emerald-800 text-emerald-800 border-emerald-800",
         };
       case "pending":
         return {

--- a/src/components/modules/marketplace/ui/pages/MarketplacePage.tsx
+++ b/src/components/modules/marketplace/ui/pages/MarketplacePage.tsx
@@ -56,7 +56,7 @@ export function MarketplacePage() {
       {/* Header */}
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
-          <div className="h-6 md:h-8 w-1 bg-gradient-to-b from-emerald-500 to-teal-500 rounded-full" />
+          <div className="h-6 md:h-8 w-1 bg-gradient-to-b from-emerald-800 to-teal-500 rounded-full" />
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
             Marketplace
           </h1>
@@ -80,7 +80,7 @@ export function MarketplacePage() {
             </div>
             <Button
               onClick={toggleForm}
-              className="bg-gradient-to-r from-emerald-600 to-teal-500 hover:from-emerald-700 hover:to-teal-600 text-white gap-2 w-full sm:w-auto"
+              className="bg-gradient-to-r from-emerald-800 to-teal-500 hover:from-emerald-800 hover:to-teal-600 text-white gap-2 w-full sm:w-auto"
             >
               <Plus className="h-4 w-4" />
               {showForm ? "Cancel" : "Offer Loan"}
@@ -91,10 +91,10 @@ export function MarketplacePage() {
         <CardContent className="space-y-6">
           {/* Loan Creation Form */}
           {showForm && (
-            <Card className="bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 border-emerald-100 dark:border-emerald-900/50 mx-4 md:mx-0">
+            <Card className="bg-gradient-to-br from-emerald-800 to-teal-50 dark:from-emerald-800 dark:to-teal-950/30 border-emerald-800 dark:border-emerald-800 mx-4 md:mx-0">
               <CardHeader className="pb-3 px-4 md:px-6">
                 <CardTitle className="text-base md:text-lg flex items-center gap-2">
-                  <Plus className="h-4 md:h-5 w-4 md:w-5 text-emerald-600" />
+                  <Plus className="h-4 md:h-5 w-4 md:w-5 text-emerald-800" />
                   Create Loan Offer
                 </CardTitle>
                 <CardDescription className="text-sm">
@@ -157,7 +157,7 @@ export function MarketplacePage() {
                 <div className="flex justify-end pt-2">
                   <Button
                     onClick={addLoan}
-                    className="bg-gradient-to-r from-emerald-600 to-teal-500 hover:from-emerald-700 hover:to-teal-600 text-white w-full sm:w-auto"
+                    className="bg-gradient-to-r from-emerald-800 to-teal-500 hover:from-emerald-800 hover:to-teal-600 text-white w-full sm:w-auto"
                   >
                     Create Offer
                   </Button>
@@ -173,18 +173,18 @@ export function MarketplacePage() {
                 key={loan.id}
                 className="overflow-hidden border-border shadow-sm hover:shadow-md transition-all duration-200 hover:-translate-y-1"
               >
-                <div className="h-1 bg-gradient-to-r from-emerald-400 to-teal-400" />
+                <div className="h-1 bg-gradient-to-r from-emerald-800 to-teal-400" />
                 <CardHeader className="pb-3 px-4 md:px-6">
                   <div className="flex items-center justify-between">
                     <CardTitle className="text-base md:text-lg flex items-center gap-2">
-                      <User className="h-4 w-4 text-emerald-600" />
+                      <User className="h-4 w-4 text-emerald-800" />
                       {loan.lender}
                     </CardTitle>
                     {getStatusBadge(loan.status)}
                   </div>
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">
-                      <span className="text-xl md:text-2xl font-bold text-emerald-600">
+                      <span className="text-xl md:text-2xl font-bold text-emerald-800">
                         {formatCurrency(loan.amount)}
                       </span>
                       <span className="text-base md:text-lg font-semibold text-teal-600">
@@ -232,7 +232,7 @@ export function MarketplacePage() {
                     </div>
                     <Button
                       size="sm"
-                      className="w-full bg-gradient-to-r from-emerald-600 to-teal-500 hover:from-emerald-700 hover:to-teal-600 text-white gap-2 h-9"
+                      className="w-full bg-gradient-to-r from-emerald-800 to-teal-500 hover:from-emerald-800 hover:to-teal-600 text-white gap-2 h-9"
                       disabled={loan.status !== "available"}
                     >
                       {loan.status === "available" ? (
@@ -265,7 +265,7 @@ export function MarketplacePage() {
               </p>
               <Button
                 onClick={() => toggleForm()}
-                className="bg-gradient-to-r from-emerald-600 to-teal-500 hover:from-emerald-700 hover:to-teal-600 text-white w-full sm:w-auto"
+                className="bg-gradient-to-r from-emerald-800 to-teal-500 hover:from-emerald-800 hover:to-teal-600 text-white w-full sm:w-auto"
               >
                 Create First Offer
               </Button>

--- a/src/components/modules/profile/ui/UserProfileForm.tsx
+++ b/src/components/modules/profile/ui/UserProfileForm.tsx
@@ -64,7 +64,7 @@ export const UserProfileForm = () => {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+        <Loader2 className="h-8 w-8 animate-spin text-emerald-800" />
       </div>
     );
   }
@@ -76,7 +76,7 @@ export const UserProfileForm = () => {
           <CardHeader className="pb-3">
             {/* Progress Bar */}
             <div className="w-full bg-primary rounded-full h-1 mb-8">
-              <div className="bg-emerald-600 h-1 rounded-full w-full"></div>
+              <div className="bg-emerald-800 h-1 rounded-full w-full"></div>
             </div>
 
             <h1 className="text-3xl font-bold mb-2">User Registration</h1>
@@ -261,7 +261,7 @@ export const UserProfileForm = () => {
                 <Button
                   type="submit"
                   disabled={saving}
-                  className="w-full bg-emerald-600 cursor-pointer hover:bg-emerald-700 text-white font-semibold py-3 rounded-lg transition-colors"
+                  className="w-full bg-emerald-800 cursor-pointer hover:bg-emerald-800 text-white font-semibold py-3 rounded-lg transition-colors"
                 >
                   {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   Save Profile

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -32,13 +32,13 @@ const ProgressTwo = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-2 w-full overflow-hidden rounded-full bg-green-500/10",
+      "relative h-2 w-full overflow-hidden rounded-full bg-emerald-800",
       className,
     )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-green-500 transition-all"
+      className="h-full w-full flex-1 bg-emerald-800 transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
## Summary
- replace all green Tailwind classes with `emerald-800`
- update progress indicators and badges to use `emerald-800`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68539251b0688320b2c661a38ec80a36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated all UI elements previously using lighter emerald and green shades to a uniform darker emerald-800 color across the application.
  - Adjusted backgrounds, borders, text, icons, badges, gradients, buttons, progress bars, and avatar elements for a consistent visual theme.
  - No changes to application logic, structure, or functionality; all modifications are purely visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->