### PR TITLE
Enforce wallet login

### DIFF
--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,19 +1,32 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Header } from "@/components/layouts/header/Header";
+import { useWalletContext } from "@/providers/wallet.provider";
+import { useRouter } from "next/navigation";
 
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { walletAddress } = useWalletContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!walletAddress) {
+      router.replace("/");
+    }
+  }, [walletAddress, router]);
+
+  if (!walletAddress) {
+    return null;
+  }
+
   return (
     <div className="min-h-screen flex flex-col w-full bg-neutral-900">
       <Header />
-      <main className="flex-1 overflow-auto">
-        {children}
-      </main>
+      <main className="flex-1 overflow-auto">{children}</main>
     </div>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -17,9 +17,9 @@ export default function Page() {
   }, [walletAddress, router]);
 
   return (
-    <>
+    <div className="min-h-screen flex flex-col w-full bg-neutral-900">
       <HeaderHome />
       <HomePage />
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/modules/auth/hooks/wallet.hook.ts
+++ b/frontend/src/components/modules/auth/hooks/wallet.hook.ts
@@ -4,10 +4,12 @@ import { ISupportedWallet } from "@creit.tech/stellar-wallets-kit";
 import { db, doc, getDoc, setDoc } from "@/lib/firebase";
 import { UserProfile } from "@/@types/user.entity";
 import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 
 export const useWallet = () => {
   // Get wallet info from wallet context
   const { setWalletInfo, clearWalletInfo } = useWalletContext();
+  const router = useRouter();
 
   /**
    * Connect to a wallet using the Stellar Wallet Kit and set the wallet info in the wallet context
@@ -75,6 +77,7 @@ export const useWallet = () => {
   const handleDisconnect = async () => {
     try {
       await disconnectWallet();
+      router.push("/");
     } catch (error) {
       console.error("Error disconnecting wallet:", error);
     }

--- a/frontend/src/components/modules/auth/ui/pages/Home.tsx
+++ b/frontend/src/components/modules/auth/ui/pages/Home.tsx
@@ -37,18 +37,6 @@ export default function HomePage() {
                   opportunity.
                 </p>
               </div>
-
-              <div className="flex flex-col sm:flex-row gap-3 items-center justify-center md:justify-start pt-4">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="border-0 text-white"
-                  onClick={handleConnect}
-                >
-                  <LogIn className="h-3.5 w-3.5 mr-1.5" />
-                  Connect Wallet
-                </Button>
-              </div>
             </div>
           </div>
         </section>

--- a/frontend/src/components/modules/auth/ui/pages/Home.tsx
+++ b/frontend/src/components/modules/auth/ui/pages/Home.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { ArrowRight } from "lucide-react";
+import { LogIn } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import Link from "next/link";
+import { useWallet } from "@/components/modules/auth/hooks/wallet.hook";
 
 export default function HomePage() {
+  const { handleConnect } = useWallet();
+
   return (
     <div className="flex flex-col bg-neutral-900 text-neutral-200">
       <main className="flex-grow">
@@ -37,16 +39,15 @@ export default function HomePage() {
               </div>
 
               <div className="flex flex-col sm:flex-row gap-3 items-center justify-center md:justify-start pt-4">
-                <Link href="/dashboard" className="w-full sm:w-auto">
-                  <Button
-                    size="lg"
-                    variant="outline"
-                    className="w-full border-emerald-600 text-emerald-300 hover:bg-emerald-700/30 hover:text-emerald-200 bg-transparent"
-                  >
-                    Explore Dashboard
-                    <ArrowRight className="ml-2 h-5 w-5" />
-                  </Button>
-                </Link>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-0 text-white"
+                  onClick={handleConnect}
+                >
+                  <LogIn className="h-3.5 w-3.5 mr-1.5" />
+                  Connect Wallet
+                </Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- restrict `/dashboard` access until wallet login
- redirect to home on wallet disconnect

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868a989d6608320b1e3eb6d9e1793d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic redirection to the homepage if the wallet is not connected when accessing the dashboard.
  * Users are now redirected to the homepage after disconnecting their wallet.
  * Updated the homepage to replace the "Explore Dashboard" link with a "Connect Wallet" button for easier wallet connection.

* **Bug Fixes**
  * Prevented the dashboard from rendering when no wallet is connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->