### PR TITLE
fix: login message to display profile name instead of wallet name

### DIFF
--- a/frontend/src/components/layouts/header/Header.tsx
+++ b/frontend/src/components/layouts/header/Header.tsx
@@ -8,7 +8,7 @@ import { useWalletContext } from "@/providers/wallet.provider";
 
 export default function Header() {
   const pathname = usePathname();
-  const { walletAddress } = useWalletContext();
+  const { walletAddress, walletName } = useWalletContext();
   const { handleConnect, handleDisconnect } = useWallet();
 
   const truncateAddress = (address: string) => {
@@ -71,7 +71,11 @@ export default function Header() {
               <div className="wallet-btn">
                 <i className="fas fa-wallet mr-2"></i>
                 <span className="wallet-address">
-                  {truncateAddress(walletAddress)}
+                {/* Show profile name if available, otherwise truncated address */}
+                {walletName && walletName !== "Freighter" 
+                  ? walletName 
+                  : truncateAddress(walletAddress)
+                }
                 </span>
                 <i className="fas fa-chevron-down ml-2 text-xs text-gray-400"></i>
               </div>

--- a/frontend/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
+++ b/frontend/src/components/modules/dashboard/ui/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import StatCard from "../cards/StatCard";
 import RecentActivityFeed from "../activity/RecentActivityFeed";
 import { useDashboard } from "../../hooks/useDashboard.hook";
+import { useUserContext } from "@/providers/user.provider";
 import {
   formatCurrency,
   UserPosition,
@@ -23,6 +24,8 @@ export default function Dashboard() {
     cardsLoading,
     error,
   } = useDashboard();
+  
+  const { profile } = useUserContext();
 
   const handleManagePosition = () => {
     alert(
@@ -154,7 +157,19 @@ export default function Dashboard() {
 
   const getWalletDisplayName = () => {
     if (!address) return "Usuario";
-    if (walletName) return walletName;
+    
+    // Use profile name if available
+    if (profile && (profile.firstName || profile.lastName)) {
+      const profileName = `${profile.firstName} ${profile.lastName}`.trim();
+      if (profileName) return profileName;
+    }
+    
+    // 2: Use walletName if it's not "Freighter"
+    if (walletName && walletName !== "Freighter") {
+      return walletName;
+    }
+    
+    // Fallback: Use truncated address
     return `${address.slice(0, 4)}...${address.slice(-4)}`;
   };
 

--- a/frontend/src/components/modules/profile/ui/UserProfileForm.tsx
+++ b/frontend/src/components/modules/profile/ui/UserProfileForm.tsx
@@ -11,7 +11,7 @@ import { profileSchema } from "../schemas/profile.schema";
 
 export default function Profile() {
   const { profile, loading, saving, saveProfile } = useUserContext();
-  const { walletAddress } = useWalletContext();
+  const { walletAddress, updateDisplayName } = useWalletContext();
 
   const form = useForm<z.infer<typeof profileSchema>>({
     resolver: zodResolver(profileSchema),

--- a/frontend/src/components/modules/profile/ui/UserProfileForm.tsx
+++ b/frontend/src/components/modules/profile/ui/UserProfileForm.tsx
@@ -11,7 +11,7 @@ import { profileSchema } from "../schemas/profile.schema";
 
 export default function Profile() {
   const { profile, loading, saving, saveProfile } = useUserContext();
-  const { walletAddress, updateDisplayName } = useWalletContext();
+  const { walletAddress } = useWalletContext();
 
   const form = useForm<z.infer<typeof profileSchema>>({
     resolver: zodResolver(profileSchema),

--- a/frontend/src/providers/user.provider.tsx
+++ b/frontend/src/providers/user.provider.tsx
@@ -16,7 +16,7 @@ const UserContext = createContext<UserContextType | undefined>(undefined);
 export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const { walletAddress } = useWalletContext();
+  const { walletAddress, updateDisplayName } = useWalletContext();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -38,7 +38,16 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
       const userDoc = await getDoc(doc(db, "users", walletAddress));
 
       if (userDoc.exists()) {
-        setProfile(userDoc.data() as unknown as UserProfile);
+        const userData = userDoc.data() as UserProfile;
+        setProfile(userData);
+        
+        // Update display name if profile has name information
+        if (userData.firstName || userData.lastName) {
+          const displayName = `${userData.firstName} ${userData.lastName}`.trim();
+          if (displayName) {
+            updateDisplayName(displayName);
+          }
+        }
       } else {
         setProfile(null);
       }
@@ -68,6 +77,15 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
 
       await setDoc(doc(db, "users", walletAddress), userData);
       setProfile(userData);
+      
+      // Update display name in wallet context
+      if (data.firstName || data.lastName) {
+        const displayName = `${data.firstName} ${data.lastName}`.trim();
+        if (displayName) {
+          updateDisplayName(displayName);
+        }
+      }
+      
       toast.success("Profile saved successfully");
     } catch (error) {
       console.error("Error saving user profile:", error);

--- a/frontend/src/providers/wallet.provider.tsx
+++ b/frontend/src/providers/wallet.provider.tsx
@@ -12,6 +12,7 @@ type WalletContextType = {
   walletAddress: string | null;
   walletName: string | null;
   setWalletInfo: (address: string, name: string) => void;
+  updateDisplayName: (name: string) => void;
   clearWalletInfo: () => void;
 };
 
@@ -43,6 +44,14 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     localStorage.setItem("walletName", name);
   };
 
+   /**
+    * Update display name 
+    * @param name 
+    */
+  const updateDisplayName = (name: string) => {
+    setWalletName(name);
+  };
+
   /**
    * Clear wallet info
    */
@@ -55,7 +64,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <WalletContext.Provider
-      value={{ walletAddress, walletName, setWalletInfo, clearWalletInfo }}
+      value={{ walletAddress, walletName, setWalletInfo, updateDisplayName, clearWalletInfo }}
     >
       {children}
     </WalletContext.Provider>


### PR DESCRIPTION
# Pull Request for TrustBridge - Close Issue

❗ **Pull Request Information**

The login message in the dashboard (and the toast) said "Welcome back, Freighter" regardless of the fact if the user had a profile name or not. Now, the user sees their name on the dashboard (and toast), if they have changed it. If not, their wallet name will appear.


## 🌀 Summary of Changes

- Made changes to the wallet hook and user provider, it now checks for user data in Firebase, if there is profile name, it displays that. If there is not, users receives a toast to finalize their profile.
- Changes to some components to show the required name.

## 🛠 Testing

### Evidence Before Solution

<img width="1360" height="413" alt="before solution" src="https://github.com/user-attachments/assets/43ce3449-421f-4b31-8b44-3a77cbdd7332" />

### Evidence After Solution

<img width="1298" height="342" alt="image" src="https://github.com/user-attachments/assets/c768baf3-ae66-45c1-8095-49a313281652" />

---

## ✅ ESLint Compliance (Mandatory)

To ensure that the code follows project standards, please run the following command and attach a screenshot of the output:

```bash
npm run lint
```

You should see:

```
✔ No ESLint warnings or errors
```

<img width="1694" height="257" alt="image" src="https://github.com/user-attachments/assets/66d2666b-2400-4ceb-bbef-a1903b81545d" />

---

## 📂 Related Issue

This pull request will **close #233 ** upon merging.

---

🎉 Thank you for reviewing this PR! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personalized display names across the app: prefers your profile name, then your wallet name (excluding “Freighter”), then a truncated address.
  * Display name syncs live with profile updates for a consistent header and dashboard experience.

* **UX Improvements**
  * Tailored welcome messages: distinct guidance for new users and a friendly “welcome back” using your display name when available.
  * Clearer error feedback when loading profile information fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->